### PR TITLE
Refine report output

### DIFF
--- a/slurm_report/cli.py
+++ b/slurm_report/cli.py
@@ -48,8 +48,16 @@ def main():
         sys.exit(1)
 
     # Output
+    explanation = (
+        "CPU_Hours = ElapsedHours * AllocCPUS\n"
+        "GPU_Hours = ElapsedHours * AllocGPUs\n"
+        "RAM_Hours(GB-h) = ElapsedHours * AllocRAM_GB"
+    )
+
     if sys.stdout.isatty():
         from tabulate import tabulate
+        print(explanation)
         print(tabulate(report_df, headers="keys", tablefmt="grid"))
     else:
+        print(explanation)
         print(report_df.to_csv(index=False))

--- a/slurm_report/report.py
+++ b/slurm_report/report.py
@@ -41,15 +41,24 @@ def generate_report(user_ids, start, end):
 
     report_df = pd.concat([totals, part], axis=1).reset_index()
 
-    # Flatten column MultiIndex: (Metric, Partition) -> Metric_Partition
-    new_cols = ["UserID"]
+    # Flatten column MultiIndex: (Metric, Partition) -> Metric\nPartition
+    keep_cols = ["UserID"]
+    new_names = ["UserID"]
     for col in report_df.columns[1:]:
         if isinstance(col, tuple):
             metric, part_name = col
-            new_cols.append(f"{metric}_{part_name}")
+            if part_name:
+                keep_cols.append(col)
+                new_names.append(f"{metric}\n{part_name}")
         else:
-            new_cols.append(col)
-    report_df.columns = new_cols
+            keep_cols.append(col)
+            new_names.append(col)
+
+    report_df = report_df[keep_cols]
+    report_df.columns = new_names
+
+    # Add unit to RAM hours column names
+    report_df.rename(columns=lambda c: c.replace("RAM_Hours", "RAM_Hours(GB-h)"), inplace=True)
 
     # Order rows: aggregate "All" row first, then individual users
     unique_users = sorted(df["UserID"].unique())

--- a/slurm_report/utils.py
+++ b/slurm_report/utils.py
@@ -26,6 +26,12 @@ def fetch_slurm_jobs(user, start, end):
     rows = []
     for line in lines:
         user_id, partition, elapsed, alloc_cpus, alloc_tres = line.split("|")
+
+        # Some sacct job-step entries come without a user or partition. They
+        # would produce empty rows and columns like "CPU_Hours_". Skip them.
+        if not user_id or not partition:
+            continue
+
         elapsed_hours = parse_elapsed(elapsed)
         gpus = parse_gres(alloc_tres)
         ram = parse_ram(alloc_tres)


### PR DESCRIPTION
## Summary
- filter sacct rows missing user or partition
- add a short explanation before the output table
- show partition names under their metrics and label RAM hours with units

## Testing
- `pip install -e .`
- `python -m py_compile slurm_report/*.py`
- `python - <<'EOF'
import subprocess, sys
from slurm_report.cli import main

def mock_run(cmd, capture_output=True, text=True, check=True):
    from types import SimpleNamespace
    lines = [
        'ge74zix2|lrz-dgx-a100-80x8|10:00:00|2|cpu=2,gres/gpu=1,mem=8G',
        '| |05:00:00|4|cpu=4,gres/gpu=2,mem=16G'
    ]
    return SimpleNamespace(stdout='\n'.join(lines)+'\n', stderr='', returncode=0)
subprocess.run = mock_run
sys.argv=['slurm_report','--user','ge74zix2','--start','2025-01-01','--end','2025-01-02']
main()
EOF

------
https://chatgpt.com/codex/tasks/task_e_684c34cf0c048325a17e9f2010e203f6