### PR TITLE
Add optional partition breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Usage
 slurm_report --user alice --start 2025-06-01 --end 2025-06-13
 slurm_report --users alice,bob --start 2025-06-01 --end 2025-06-13
 slurm_report --userfile users.txt --start 2025-06-01 --end 2025-06-13 > output.csv
+slurm_report --user alice --start 2025-06-01 --end 2025-06-13 --partitions
 ```
 
 Dependencies

--- a/slurm_report/cli.py
+++ b/slurm_report/cli.py
@@ -12,6 +12,11 @@ def parse_args():
     group.add_argument("--userfile", help="File with one user ID per line")
     parser.add_argument("--start", required=True, help="Start date (YYYY-MM-DD)")
     parser.add_argument("--end", required=True, help="End date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--partitions",
+        action="store_true",
+        help="Include per-partition metrics in the output",
+    )
     return parser.parse_args()
 
 
@@ -42,7 +47,7 @@ def main():
             user_ids = [line.strip() for line in f if line.strip()]
 
     try:
-        report_df = generate_report(user_ids, start, end)
+        report_df = generate_report(user_ids, start, end, include_partitions=args.partitions)
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/slurm_report/report.py
+++ b/slurm_report/report.py
@@ -9,8 +9,18 @@ def compute_metrics(df):
     return df
 
 
-def generate_report(user_ids, start, end):
-    """Return a DataFrame summarising usage per user and totals."""
+def generate_report(user_ids, start, end, include_partitions=False):
+    """Return a DataFrame summarising usage per user and totals.
+
+    Parameters
+    ----------
+    user_ids : list[str]
+        User IDs to include in the report.
+    start, end : datetime
+        Date range for the report.
+    include_partitions : bool, optional
+        If True, include per-partition metrics in the returned DataFrame.
+    """
     all_jobs = []
     for user in user_ids:
         jobs = fetch_slurm_jobs(user, start, end)
@@ -31,31 +41,38 @@ def generate_report(user_ids, start, end):
 
     totals = df_all.groupby("UserID")[["CPU_Hours", "GPU_Hours", "RAM_Hours"]].sum()
 
-    part = df_all.pivot_table(
-        index="UserID",
-        columns="Partition",
-        values=["CPU_Hours", "GPU_Hours", "RAM_Hours"],
-        aggfunc="sum",
-        fill_value=0,
-    )
+    if include_partitions:
+        part = df_all.pivot_table(
+            index="UserID",
+            columns="Partition",
+            values=["CPU_Hours", "GPU_Hours", "RAM_Hours"],
+            aggfunc="sum",
+            fill_value=0,
+        )
 
-    report_df = pd.concat([totals, part], axis=1).reset_index()
+        # Sort partitions and ensure metric order
+        part = part.reindex(["CPU_Hours", "GPU_Hours", "RAM_Hours"], level=0)
+        part = part.sort_index(axis=1, level=1)
 
-    # Flatten column MultiIndex: (Metric, Partition) -> Metric\nPartition
-    keep_cols = ["UserID"]
-    new_names = ["UserID"]
-    for col in report_df.columns[1:]:
-        if isinstance(col, tuple):
-            metric, part_name = col
-            if part_name:
+        report_df = pd.concat([totals, part], axis=1).reset_index()
+
+        # Flatten column MultiIndex: (Metric, Partition) -> Metric\nPartition
+        keep_cols = ["UserID"]
+        new_names = ["UserID"]
+        for col in report_df.columns[1:]:
+            if isinstance(col, tuple):
+                metric, part_name = col
+                if part_name:
+                    keep_cols.append(col)
+                    new_names.append(f"{metric}\n{part_name}")
+            else:
                 keep_cols.append(col)
-                new_names.append(f"{metric}\n{part_name}")
-        else:
-            keep_cols.append(col)
-            new_names.append(col)
+                new_names.append(col)
 
-    report_df = report_df[keep_cols]
-    report_df.columns = new_names
+        report_df = report_df[keep_cols]
+        report_df.columns = new_names
+    else:
+        report_df = totals.reset_index()
 
     # Add unit to RAM hours column names
     report_df.rename(columns=lambda c: c.replace("RAM_Hours", "RAM_Hours(GB-h)"), inplace=True)


### PR DESCRIPTION
## Summary
- add `--partitions` flag in CLI to toggle partition metrics
- compute partition breakdown only when requested
- sort partition columns alphabetically and keep metric order
- document usage of `--partitions`

## Testing
- `python -m py_compile slurm_report/*.py`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_684c6bf12fac8325a1c860e88eb0e9f7