### PR TITLE
Add rounding for numeric columns

### DIFF
--- a/slurm_report/report.py
+++ b/slurm_report/report.py
@@ -82,4 +82,8 @@ def generate_report(user_ids, start, end, include_partitions=False):
     order = ["All"] + unique_users
     report_df = report_df.set_index("UserID").loc[order].reset_index()
 
+    # Round all numeric columns to one decimal place for cleaner output
+    numeric_cols = report_df.select_dtypes(include="number").columns
+    report_df[numeric_cols] = report_df[numeric_cols].round(1)
+
     return report_df


### PR DESCRIPTION
## Summary
- round all numeric columns in reports to one decimal place for cleaner output

## Testing
- `flake8` *(fails: line length and other issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_684c6dd348e883259129aa9e91f325a4