### PR TITLE
Add flexible date ranges to slurm_report

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ pip install -e .
 
 Usage
 ```bash
-slurm_report --user alice --start 2025-06-01 --end 2025-06-13
+slurm_report --user alice --start 2025-06        # whole month of June 2025
+slurm_report --user alice --start 2025-06-01     # from 2025-06-01 until today
 slurm_report --users alice,bob --start 2025-06-01 --end 2025-06-13
 slurm_report --userfile users.txt --start 2025-06-01 --end 2025-06-13 > output.csv
 slurm_report --user alice --start 2025-06-01 --end 2025-06-13 --partitions
 ```
+If `--end` is omitted, the tool aggregates until today when `--start` includes a day.
+If `--start` is given as just `YYYY-MM`, the report covers that entire month.
 
 Dependencies
 


### PR DESCRIPTION
## Summary
- allow `--start`/`--end` arguments to accept YYYY-MM or YYYY-MM-DD
- make `--end` optional and infer dates
- display reporting interval in output
- document new date behaviour

## Testing
- `python -m py_compile slurm_report/*.py`
- `pip install -e .`
- `slurm_report --user alice --start 2025-06 | head -n 5` *(fails: FileNotFoundError: 'sacct')*

------
https://chatgpt.com/codex/tasks/task_e_684c72c323988325a2781c16df48943a